### PR TITLE
Update conv2d_gradfix.py

### DIFF
--- a/torch_utils/ops/conv2d_gradfix.py
+++ b/torch_utils/ops/conv2d_gradfix.py
@@ -50,7 +50,7 @@ def _should_use_custom_op(input):
         return False
     if input.device.type != 'cuda':
         return False
-    if any(torch.__version__.startswith(x) for x in ['1.7.', '1.8.', '1.9']):
+    if any(torch.__version__.startswith(x) for x in ['1.7.', '1.8.', '1.9', '1.10.']):
         return True
     warnings.warn(f'conv2d_gradfix not supported on PyTorch {torch.__version__}. Falling back to torch.nn.functional.conv2d().')
     return False


### PR DESCRIPTION
Update allow version of Pytorch to 1.10

i had this error whe run the train:  stylegan conv2d_gradfix not supported on PyTorch 1.10.0+cu111

So it works without the warning when the version 1.10 is add to: 

if any(torch.__version__.startswith(x) for x in ['1.7.', '1.8.', '1.9', '1.10.']):  in line 53